### PR TITLE
Monroe Version that uses RANDOM-STATE and the compatible SHOP3 version

### DIFF
--- a/src/config.lisp
+++ b/src/config.lisp
@@ -7,7 +7,7 @@
     )
    (plan-package
     :initarg :plan-package
-    :reader plan-package
+    :type (or package string symbol)
     )
    (domain-name
     :initarg :domain-name
@@ -55,6 +55,12 @@ subgoals"))
   (:documentation "Returns a list of *unique* method schemas from 
 the domain so things like GET-TO will just be 1 schema, even though
 there are many different method bodies."))
+
+(defmethod plan-package ((obj monroe-config))
+  (with-slots (plan-package) obj
+    (etypecase plan-package
+      (package plan-package)
+      ((or symbol string) (uiop:find-package* plan-package)))))
 
 ;;; specials
 (declaim (special *top-goals* *flat-output*))

--- a/src/monroe.asd
+++ b/src/monroe.asd
@@ -3,14 +3,14 @@
   )
 (in-package :monroe-asd)
 (defsystem monroe
-  :depends-on ("shop3")
+    ;; need new version of SHOP3 with its own random function
+  :depends-on ((:version "shop3" "4"))
   :license "BSD 3-clause"
-  :serial t
-  :version "3.1"
+  :serial tg
+  :version "4.0.0"
   :components ((:file "package")
                (:file "nlib") ;; my library
                (:file "config")
-               ;; (:file "shop2random") ;; planner
                (:file "planlib")      ;; code for generating plan lib
                (:file "monroe_plib")  ;; plan library
                (:file "monroe_state") ;; state


### PR DESCRIPTION
The previous version of Monroe2 could only work with Allegro CL -- at least for scripted generation -- because it used an implementation-specific version of random seeds (CL random state objects are not portable). This replaces that with use of the random-state library.

This has actually caused problems, because there are multiple bugs in `random-state`.